### PR TITLE
feat(jit): Initialize the JIT compiler to compile template function

### DIFF
--- a/examples/jit_example.py
+++ b/examples/jit_example.py
@@ -1,0 +1,58 @@
+"""Example demonstrating the use of JIT-compiled kernels in TileFusion."""
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+
+import logging
+import time
+
+import torch
+
+import tilefusion
+
+
+def main() -> None:
+    """Run benchmark comparing TileFusion JIT kernel with PyTorch operations."""
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+    logger = logging.getLogger(__name__)
+
+    size = 10_000_000
+    input_tensor1 = torch.rand(size, dtype=torch.float32, device="cuda")
+    input_tensor2 = torch.rand(size, dtype=torch.float32, device="cuda")
+
+    tf_out = torch.zeros_like(input_tensor1)
+
+    torch_out = torch.zeros_like(input_tensor1)
+
+    logger.info("Warming up...")
+    for _ in range(5):
+        tilefusion.jit_add(input_tensor1, input_tensor2, tf_out)  # type: ignore
+        torch.add(input_tensor1, input_tensor2, out=torch_out)
+
+    logger.info("Running TileFusion JIT kernel...")
+    start = time.time()
+    for _ in range(100):
+        tilefusion.jit_add(input_tensor1, input_tensor2, tf_out)  # type: ignore
+    torch.cuda.synchronize()
+    tf_time = time.time() - start
+
+    logger.info("Running PyTorch addition...")
+    start = time.time()
+    for _ in range(100):
+        torch.add(input_tensor1, input_tensor2, out=torch_out)
+    torch.cuda.synchronize()
+    torch_time = time.time() - start
+
+    max_diff = torch.max(torch.abs(tf_out - torch_out)).item()
+    logger.info(f"Maximum absolute difference: {max_diff}")
+
+    logger.info(f"TileFusion JIT kernel time: {tf_time:.6f} seconds")
+    logger.info(f"PyTorch addition time: {torch_time:.6f} seconds")
+    logger.info(f"Speedup factor: {torch_time / tf_time:.2f}x")
+
+
+if __name__ == "__main__":
+    main()

--- a/include/jit/compiler.hpp
+++ b/include/jit/compiler.hpp
@@ -1,0 +1,88 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include <cuda.h>
+
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace tilefusion::jit {
+
+/**
+ * A simple JIT compiler for CUDA kernels.
+ * This class allows for runtime compilation of CUDA kernels using NVCC.
+ */
+class JitCompiler {
+  public:
+    // Singleton pattern
+    static JitCompiler& instance();
+
+    /**
+     * Compiles a CUDA kernel at runtime and returns a function pointer to the
+     * kernel.
+     *
+     * @param kernel_name The name of the kernel function to compile
+     * @param cuda_source The CUDA source code containing the kernel
+     * @param compile_args Additional compiler arguments to pass to NVCC
+     * @return Function pointer to the compiled kernel or nullptr if compilation
+     * fails
+     */
+    CUfunction compile_kernel(
+        const std::string& kernel_name, const std::string& cuda_source,
+        const std::vector<std::string>& compile_args = {});
+
+    /**
+     * Gets a previously compiled kernel or compiles it if it doesn't exist.
+     *
+     * @param kernel_name The name of the kernel function
+     * @param cuda_source The CUDA source code
+     * @param compile_args Additional compiler arguments
+     * @return Function pointer to the compiled kernel
+     */
+    CUfunction get_or_compile_kernel(
+        const std::string& kernel_name, const std::string& cuda_source,
+        const std::vector<std::string>& compile_args = {});
+
+    /**
+     * Clears the cache of compiled kernels.
+     */
+    void clear_cache();
+
+  private:
+    JitCompiler();
+    ~JitCompiler();
+
+    // Delete copy constructor and assignment operator
+    JitCompiler(const JitCompiler&) = delete;
+    JitCompiler& operator=(const JitCompiler&) = delete;
+
+    // Compile a CUDA source file to PTX
+    std::string compile_to_ptx(const std::string& cuda_source,
+                               const std::vector<std::string>& compile_args);
+
+    // Load a PTX string and get a handle to the specified kernel
+    CUfunction load_ptx_and_get_kernel(const std::string& ptx,
+                                       const std::string& kernel_name);
+
+    // Write a string to a temporary file
+    std::string write_to_temp_file(const std::string& content,
+                                   const std::string& extension);
+
+    // CUDA context and module
+    CUcontext cuda_context_;
+
+    // Cache of compiled kernels
+    std::unordered_map<std::string, CUmodule> module_cache_;
+    std::unordered_map<std::string, CUfunction> kernel_cache_;
+
+    // Mutex for thread safety
+    std::mutex mutex_;
+};
+
+}  // namespace tilefusion::jit

--- a/include/kernel_registry.hpp
+++ b/include/kernel_registry.hpp
@@ -19,7 +19,7 @@ namespace tilefusion {
 // import the TileFusion module in Python.
 #define TILEFUSION_EXPORT extern "C" __attribute__((visibility("default")))
 
-#define REGISTER_KERNEL(name, schema, func)                              \
+#define REGISTER_OP(name, schema, func)                                  \
     namespace {                                                          \
     static bool name##_registered = []() {                               \
         tilefusion::KernelRegistry::instance().add_kernel(#name, schema, \

--- a/include/kernels/jit_example.hpp
+++ b/include/kernels/jit_example.hpp
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "kernel_registry.hpp"
+
+#include <ATen/ATen.h>
+#include <torch/script.h>
+
+namespace tilefusion::kernels {
+
+/**
+ * Example function demonstrating the use of JIT compilation for CUDA kernels.
+ * This function takes two input tensors and an output tensor, and performs
+ * element-wise addition using a JIT-compiled CUDA kernel.
+ *
+ * @param input_a First input tensor
+ * @param input_b Second input tensor
+ * @param output Output tensor that will contain the result of input_a + input_b
+ */
+TILEFUSION_EXPORT void jit_add(at::Tensor input_a, at::Tensor input_b,
+                               at::Tensor output);
+
+}  // namespace tilefusion::kernels

--- a/include/kernels/kernel_list.hpp
+++ b/include/kernels/kernel_list.hpp
@@ -4,19 +4,22 @@
 #pragma once
 
 #include "kernel_registry.hpp"
+#include "kernels/jit_example.hpp"
 #include "kernels/mod.hpp"
 
 namespace tilefusion ::kernels {
 
-REGISTER_KERNEL(
-    scatter_nd,
-    "scatter_nd(Tensor data, Tensor(a!) updates, Tensor indices) -> ()",
-    &scatter_nd);
+REGISTER_OP(scatter_nd,
+            "scatter_nd(Tensor data, Tensor(a!) updates, Tensor indices) -> ()",
+            &scatter_nd);
 
-REGISTER_KERNEL(
+REGISTER_OP(
     flash_attention,
     "flash_attention(Tensor Q, Tensor K, Tensor V, Tensor(a!) O, "
     "int m, int n, int k, int p, float softmax_scale, bool causal) -> ()",
     &flash_attention);
+
+REGISTER_OP(jit_add, "jit_add(Tensor a, Tensor b, Tensor(a!) output) -> ()",
+            &jit_add);
 
 }  // namespace tilefusion::kernels

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -10,9 +10,11 @@ from pathlib import Path
 from typing import Any
 
 from . import ops
+from .ops import jit_add
 
 __all__ = [
     "ops",
+    "jit_add",
 ]
 
 

--- a/python/ops/__init__.py
+++ b/python/ops/__init__.py
@@ -6,9 +6,11 @@
 # --------------------------------------------------------------------------
 
 from .flash_attention import TiledFlashAttention
+from .jit_add import jit_add
 from .scatter_nd import scatter_nd
 
 __all__ = [
     "TiledFlashAttention",
     "scatter_nd",
+    "jit_add",
 ]

--- a/python/ops/jit_add.py
+++ b/python/ops/jit_add.py
@@ -1,0 +1,45 @@
+"""JIT-compiled addition kernel example."""
+
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License.
+# --------------------------------------------------------------------------
+
+import torch
+import torch.autograd
+
+
+def jit_add(
+    input1: torch.Tensor,
+    input2: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """JIT-compiled element-wise addition.
+
+    This function performs element-wise addition of two tensors using a
+    JIT-compiled CUDA kernel.
+
+    Args:
+        input1: First input tensor
+        input2: Second input tensor
+        output: Output tensor that will store the result
+
+    Raises:
+        RuntimeError: If inputs are not CUDA tensors of the same shape and type.
+    """
+    # Validate inputs
+    if not input1.is_cuda or not input2.is_cuda or not output.is_cuda:
+        raise RuntimeError("All tensors must be CUDA tensors")
+
+    if input1.shape != input2.shape or input1.shape != output.shape:
+        raise RuntimeError("All tensors must have the same shape")
+
+    if (
+        input1.dtype != torch.float32
+        or input2.dtype != torch.float32
+        or output.dtype != torch.float32
+    ):
+        raise RuntimeError("All tensors must be of type float32")
+
+    # Call the C++ function
+    torch.ops.tilefusion.jit_add(input1, input2, output)

--- a/run_build.sh
+++ b/run_build.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+cur_dir=$(pwd)
+build_dir="$cur_dir/build/temp.linux-x86_64-cpython-312"
+
+lib_dir="$build_dir/src"
+lib_name="libtilefusion.so"
+
+source_lib="$lib_dir/$lib_name"
+target_lib="tilefusion/$lib_name"
+
+if [ -f "$source_lib" ]; then
+    rm -rf "$source_lib"
+fi
+
+if [ -f "$target_lib" ]; then
+    rm -rf "$target_lib"
+fi
+
+cd $build_dir
+
+if [ -f "CMakeCache.txt" ]; then
+    rm -rf CMakeCache.txt CMakeFiles
+fi
+
+if [ -d "CMakeFiles" ]; then
+    rm -rf CMakeFiles
+fi
+
+cmake ../../
+
+make -j32 2>&1 | tee ../../build.log
+
+cd $cur_dir
+
+if [ -f "$source_lib" ]; then
+    cp "$source_lib" "$target_lib"
+else
+    echo "Failed to build TileFusion library"
+    exit 1
+fi
+
+exit 0
+
+python setup.py develop 2>&1 | tee build.log
+
+# ./test.sh 2>&1 | tee test.log

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,10 +5,15 @@
 
 set(TARGET "tilefusion")
 
-file(GLOB_RECURSE SOURCES "kernels/*.cu" "*.cc")
+file(GLOB_RECURSE SOURCES "kernels/*.cu" "kernels/*.cc" "*.cc")
 
+# Create the target first before setting properties
 cuda_add_library(${TARGET} SHARED ${SOURCES})
 
+# Define path for NVCC
+add_compile_definitions(NVCC_PATH="${CMAKE_CUDA_COMPILER}")
+
+# Now set properties on the existing target
 set_target_properties(
   ${TARGET}
   PROPERTIES CXX_STANDARD 20
@@ -46,4 +51,8 @@ target_compile_options(
          --generate-line-info
          >)
 target_compile_features(${TARGET} PUBLIC cxx_std_20 cuda_std_20)
-target_link_libraries(${TARGET} "${TORCH_LIBRARIES}")
+
+# Link with CUDA libraries
+find_package(CUDAToolkit REQUIRED)
+target_link_libraries(${TARGET} "${TORCH_LIBRARIES}" CUDA::cudart
+                      CUDA::cuda_driver)

--- a/src/jit/compiler.cc
+++ b/src/jit/compiler.cc
@@ -1,0 +1,225 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "jit/compiler.hpp"
+
+#include "cuda_utils.hpp"
+
+#include <array>
+#include <cstdio>
+#include <fstream>
+#include <iostream>
+#include <memory>
+#include <random>
+#include <sstream>
+#include <stdexcept>
+
+namespace tilefusion::jit {
+
+namespace {
+// Generate a random string to use as part of the temp file name
+std::string generate_random_string(size_t length) {
+    static const char alphanum[] =
+        "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+    std::random_device rd;
+    std::mt19937 gen(rd());
+    std::uniform_int_distribution<> dist(0, sizeof(alphanum) - 2);
+
+    std::string result;
+    result.reserve(length);
+    for (size_t i = 0; i < length; ++i) {
+        result += alphanum[dist(gen)];
+    }
+    return result;
+}
+
+std::string exec_cmd(const std::string& cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::unique_ptr<FILE, decltype(&pclose)> pipe(popen(cmd.c_str(), "r"),
+                                                  pclose);
+
+    if (!pipe) {
+        throw std::runtime_error("popen() failed!");
+    }
+
+    while (fgets(buffer.data(), buffer.size(), pipe.get()) != nullptr) {
+        result += buffer.data();
+    }
+
+    return result;
+}
+
+std::string get_hash_key(const std::string& kernel_name,
+                         const std::string& cuda_source,
+                         const std::vector<std::string>& compile_args) {
+    std::stringstream ss;
+    ss << kernel_name << "___";
+    ss << cuda_source << "___";
+    for (const auto& arg : compile_args) {
+        ss << arg << " ";
+    }
+
+    return ss.str();
+}
+
+std::string get_nvcc_path() {
+#ifdef NVCC_PATH
+    return NVCC_PATH;
+#else
+    return "nvcc";
+#endif
+}
+
+}  // anonymous namespace
+
+JitCompiler& JitCompiler::instance() {
+    static JitCompiler instance;
+    return instance;
+}
+
+JitCompiler::JitCompiler() {
+    CUresult result = cuInit(0);
+    if (result != CUDA_SUCCESS) {
+        throw std::runtime_error("Failed to initialize CUDA driver");
+    }
+
+    result = cuCtxGetCurrent(&cuda_context_);
+    if (result != CUDA_SUCCESS) {
+        CUdevice device;
+        result = cuDeviceGet(&device, 0);
+        if (result != CUDA_SUCCESS) {
+            throw std::runtime_error("Failed to get CUDA device");
+        }
+
+        result = cuCtxCreate(&cuda_context_, 0, device);
+        if (result != CUDA_SUCCESS) {
+            throw std::runtime_error("Failed to create CUDA context");
+        }
+    }
+}
+
+JitCompiler::~JitCompiler() {
+    for (auto& [key, module] : module_cache_) {
+        cuModuleUnload(module);
+    }
+}
+
+CUfunction JitCompiler::compile_kernel(
+    const std::string& kernel_name, const std::string& cuda_source,
+    const std::vector<std::string>& compile_args) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    std::string key = get_hash_key(kernel_name, cuda_source, compile_args);
+
+    auto kernel_it = kernel_cache_.find(key);
+    if (kernel_it != kernel_cache_.end()) {
+        return kernel_it->second;
+    }
+
+    try {
+        std::string ptx = compile_to_ptx(cuda_source, compile_args);
+
+        CUfunction kernel = load_ptx_and_get_kernel(ptx, kernel_name);
+
+        kernel_cache_[key] = kernel;
+
+        return kernel;
+    } catch (const std::exception& e) {
+        std::cerr << "Error compiling kernel: " << e.what() << std::endl;
+        return nullptr;
+    }
+}
+
+CUfunction JitCompiler::get_or_compile_kernel(
+    const std::string& kernel_name, const std::string& cuda_source,
+    const std::vector<std::string>& compile_args) {
+    return compile_kernel(kernel_name, cuda_source, compile_args);
+}
+
+void JitCompiler::clear_cache() {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    for (auto& [key, module] : module_cache_) {
+        cuModuleUnload(module);
+    }
+
+    module_cache_.clear();
+    kernel_cache_.clear();
+}
+
+std::string JitCompiler::compile_to_ptx(
+    const std::string& cuda_source,
+    const std::vector<std::string>& compile_args) {
+    // Write the CUDA source to a temporary file
+    std::string cu_file = write_to_temp_file(cuda_source, ".cu");
+
+    std::stringstream cmd;
+    cmd << get_nvcc_path() << " -ptx ";
+
+    cmd << "-arch=sm_70 ";  // FIXME(ying): Auto-detect this
+
+    for (const auto& arg : compile_args) {
+        cmd << arg << " ";
+    }
+
+    std::string ptx_file = cu_file.substr(0, cu_file.size() - 3) + ".ptx";
+    cmd << cu_file << " -o " << ptx_file;
+
+    std::string output = exec_cmd(cmd.str());
+
+    std::ifstream ptx_stream(ptx_file);
+    if (!ptx_stream.good()) {
+        throw std::runtime_error("Failed to compile CUDA source: " + output);
+    }
+
+    std::stringstream ptx_content;
+    ptx_content << ptx_stream.rdbuf();
+
+    std::remove(cu_file.c_str());
+    std::remove(ptx_file.c_str());
+
+    return ptx_content.str();
+}
+
+CUfunction JitCompiler::load_ptx_and_get_kernel(
+    const std::string& ptx, const std::string& kernel_name) {
+    std::string module_key = kernel_name + "_" + generate_random_string(10);
+
+    CUmodule module;
+    CUresult result = cuModuleLoadData(&module, ptx.c_str());
+    if (result != CUDA_SUCCESS) {
+        throw std::runtime_error("Failed to load PTX module");
+    }
+
+    CUfunction kernel;
+    result = cuModuleGetFunction(&kernel, module, kernel_name.c_str());
+    if (result != CUDA_SUCCESS) {
+        cuModuleUnload(module);
+        throw std::runtime_error("Failed to get kernel function: " +
+                                 kernel_name);
+    }
+
+    module_cache_[module_key] = module;
+
+    return kernel;
+}
+
+std::string JitCompiler::write_to_temp_file(const std::string& content,
+                                            const std::string& extension) {
+    std::string filename =
+        "/tmp/tilefusion_" + generate_random_string(10) + extension;
+
+    std::ofstream out(filename);
+    if (!out.good()) {
+        throw std::runtime_error("Failed to create temporary file: " +
+                                 filename);
+    }
+
+    out << content;
+    out.close();
+
+    return filename;
+}
+
+}  // namespace tilefusion::jit

--- a/src/kernels/jit_example.cc
+++ b/src/kernels/jit_example.cc
@@ -1,0 +1,93 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+#include "kernels/jit_example.hpp"
+
+#include "cuda_utils.hpp"
+#include "jit/compiler.hpp"
+#include "kernel_registry.hpp"
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+
+#include <iostream>
+#include <sstream>
+
+namespace tilefusion::kernels {
+
+namespace {
+// The CUDA kernel source code for element-wise addition
+const std::string kAddKernelSource = R"(
+extern "C" __global__ void add_kernel(const float* a, const float* b, float* out, int n) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        out[idx] = a[idx] + b[idx];
+    }
+}
+)";
+}  // namespace
+
+void jit_add(at::Tensor input_a, at::Tensor input_b, at::Tensor output) {
+    // Validate input
+    if (!input_a.is_cuda() || !input_b.is_cuda() || !output.is_cuda()) {
+        throw std::runtime_error("All tensors must be CUDA tensors");
+    }
+
+    if (input_a.sizes() != input_b.sizes() ||
+        input_a.sizes() != output.sizes()) {
+        throw std::runtime_error("All tensors must have the same shape");
+    }
+
+    if (input_a.dtype() != torch::kFloat32 ||
+        input_b.dtype() != torch::kFloat32 ||
+        output.dtype() != torch::kFloat32) {
+        throw std::runtime_error("All tensors must be of type float32");
+    }
+
+    // Get total number of elements
+    int n = input_a.numel();
+    if (n == 0) return;
+
+    // Compile or retrieve the kernel
+    auto& jit = tilefusion::jit::JitCompiler::instance();
+    CUfunction kernel =
+        jit.get_or_compile_kernel("add_kernel", kAddKernelSource);
+
+    if (!kernel) {
+        throw std::runtime_error("Failed to compile or retrieve kernel");
+    }
+
+    // Set up grid and block dimensions
+    int blockSize = 256;
+    int gridSize = (n + blockSize - 1) / blockSize;
+
+    // Store pointers in variables first
+    float* a_ptr = input_a.data_ptr<float>();
+    float* b_ptr = input_b.data_ptr<float>();
+    float* out_ptr = output.data_ptr<float>();
+
+    // Set up kernel parameters using the variables
+    void* args[] = {&a_ptr, &b_ptr, &out_ptr, &n};
+
+    // Launch the kernel
+    CUresult result = cuLaunchKernel(kernel, gridSize, 1, 1,  // Grid dimensions
+                                     blockSize, 1, 1,  // Block dimensions
+                                     0,                // Shared memory size
+                                     nullptr,          // Stream
+                                     args,             // Arguments
+                                     nullptr           // Extra
+    );
+
+    if (result != CUDA_SUCCESS) {
+        throw std::runtime_error("Failed to launch kernel");
+    }
+
+    // Synchronize to make sure the kernel is completed
+    cudaDeviceSynchronize();
+}
+
+// Register the kernel with TileFusion's kernel registry
+REGISTER_OP(jit_add, "jit_add(Tensor a, Tensor b, Tensor(a!) output) -> ()",
+            &jit_add);
+
+}  // namespace tilefusion::kernels

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+pytest tests/python/test_scatter_nd.py 2>&1 | tee test.log
+pytest tests/python/test_flash_attn.py 2>&1 | tee -a test.log


### PR DESCRIPTION
This PR is experimental and a work in progress, aiming to introduce a JIT compiler for CUDA kernels that enables runtime compilation using NVCC. The implementation initializes:

- A JIT compiler class that compiles CUDA source code to PTX;
- A caching mechanism for compiled kernels to enhance performance;
- Safe handling of kernel parameters and CUDA context management;
- An example kernel implementation (vector addition) to demonstrate usage;
- Python bindings through the TileFusion API;

The JIT compiler offers a flexible way to dynamically generate optimized CUDA kernels at runtime without the need for pre-compilation, supporting more dynamic workloads and experimental kernel development.