### PR TITLE
fix: Replace hard-coded shared memory limit with dynamic device query

### DIFF
--- a/include/cuda_info.hpp
+++ b/include/cuda_info.hpp
@@ -32,4 +32,7 @@ std::string GetDeviceName();
 
 // Returns the compute capability of the current device.
 std::string GetComputeCapability();
+
+// Returns the maximum shared memory per block for the current device.
+int GetMaxSharedMemoryPerBlock();
 }  // namespace tilefusion

--- a/include/kernels/kernel_list.hpp
+++ b/include/kernels/kernel_list.hpp
@@ -19,7 +19,8 @@ REGISTER_OP(
     &flash_attention);
 
 REGISTER_OP(fused_two_gemms,
-            "fused_two_gemms(Tensor A, Tensor B, Tensor C, Tensor(a!) D) ->()",
+            "fused_two_gemms(Tensor A, Tensor B, Tensor C, Tensor(a!) D, "
+            "int tm, int tn, int tk, int tp) ->()",
             &fused_two_gemms);
 
 }  // namespace tilefusion::kernels

--- a/include/kernels/ops.hpp
+++ b/include/kernels/ops.hpp
@@ -66,10 +66,11 @@ TILEFUSION_EXPORT void scatter_nd(const torch::Tensor& data,
                                   torch::Tensor& updates,
                                   const torch::Tensor& indices);
 
-// declare the host function for flash attention
+// declare the host function for fused two gemms
 TILEFUSION_EXPORT void fused_two_gemms(const torch::Tensor& A,
                                        const torch::Tensor& B,
-                                       const torch::Tensor& C,
-                                       torch::Tensor& D);
+                                       const torch::Tensor& C, torch::Tensor& D,
+                                       int64_t tm, int64_t tn, int64_t tk,
+                                       int64_t tp);
 
 }  // namespace tilefusion::kernels

--- a/python/ops/fused_two_gemms.py
+++ b/python/ops/fused_two_gemms.py
@@ -43,6 +43,10 @@ def fused_two_gemms(
     input_b: torch.Tensor,
     input_c: torch.Tensor,
     output: torch.Tensor,
+    tm: int = 64,
+    tn: int = 64,
+    tk: int = 64,
+    tp: int = 64,
 ) -> None:
     """Fused two gemms implementation.
 
@@ -60,10 +64,16 @@ def fused_two_gemms(
                  in the column-major fashion.
         output: The output matrix with a shape of (M, P), laid out in the
                 row-major fashion.
+        tm: The shared memory tile size of the m-dimension.
+        tn: The shared memory tile size of the n-dimension.
+        tk: The shared memory tile size of the k-dimension.
+        tp: The shared memory tile size of the p-dimension.
     """
     _validate_tensor(input_a, "input_a")
     _validate_tensor(input_b, "input_b")
     _validate_tensor(input_c, "input_c")
     _validate_tensor(output, "output")
 
-    torch.ops.tilefusion.fused_two_gemms(input_a, input_b, input_c, output)
+    torch.ops.tilefusion.fused_two_gemms(
+        input_a, input_b, input_c, output, tm, tn, tk, tp
+    )

--- a/src/cuda_info.cc
+++ b/src/cuda_info.cc
@@ -100,4 +100,13 @@ std::string GetComputeCapability() {
     return ss.str();
 }
 
+int GetMaxSharedMemoryPerBlock() {
+    int device_id;
+    CUDA_CHECK(cudaGetDevice(&device_id));
+
+    cudaDeviceProp prop;
+    CUDA_CHECK(cudaGetDeviceProperties(&prop, device_id));
+    return prop.sharedMemPerBlock;
+}
+
 }  // namespace tilefusion

--- a/src/kernels/fused_two_gemms.cu
+++ b/src/kernels/fused_two_gemms.cu
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 #include "cell/mod.hpp"
+#include "cuda_info.hpp"
 #include "jit/mod.hpp"
 #include "kernels/common.hpp"
 #include "kernels/ops.hpp"
@@ -12,10 +13,29 @@ using namespace tilefusion;
 namespace tl = tile_layout;
 
 namespace {
+
+/// @brief Generate the kernel wrapper for the fused two gemms kernel.
+///        D = A @ B @ C
+///        where A has a shape of (m, k) and laid out in row-major fashion,
+///        B has a shape of (k, n) and laid out in column-major fashion,
+///        C has a shape of (n, p) and laid out in column-major fashion,
+///        D has a shape of (m, p) and laid out in row-major fashion.
+/// @param in_type The input type.
+/// @param acc_type The accumulation type.
+/// @param m The number of rows of the input matrix A.
+/// @param n The number of rows of the input matrix B.
+/// @param k The number of columns of the input matrices A and B.
+/// @param p The number of columns of the input matrix C.
+/// @param tm The shared memory tile size of the m-dimension.
+/// @param tn The shared memory tile size of the n-dimension.
+/// @param tk The shared memory tile size of the k-dimension.
+/// @param tp The shared memory tile size of the p-dimension.
+/// @return The kernel wrapper for the fused two gemms kernel.
 std::string generate_kernel_wrapper(const std::string& in_type,
-                                    const std::string& acc_type, int m, int n,
-                                    int k, int p, int kTM, int kTN, int kTK,
-                                    int kTP) {
+                                    const std::string& acc_type, int64_t m,
+                                    int64_t n, int64_t k, int64_t p,
+                                    int64_t tm = 64, int64_t tn = 64,
+                                    int64_t tk = 64, int64_t tp = 64) {
     std::stringstream ss;
     ss << R"(
 #include "kernels/fused_two_gemms_device.cuh"
@@ -24,8 +44,8 @@ using namespace tilefusion::kernels;
 using Config = FusedTwoGemmsTraits<)"
        << in_type << ", " << acc_type << R"(,
         tl::RowMajor<2, 1>, )"
-       << m << ", " << n << ", " << k << ", " << p << "," << kTM << ", " << kTN
-       << ", " << kTK << ", " << kTP << R"(>;
+       << m << ", " << n << ", " << k << ", " << p << ", " << tm << ", " << tn
+       << ", " << tk << ", " << tp << R"(>;
 
 extern "C" __global__ void fused_two_gemms_kernel_)"
        << in_type << "_" << acc_type << "_" << m << "_" << n << "_" << k << "_"
@@ -38,7 +58,8 @@ extern "C" __global__ void fused_two_gemms_kernel_)"
 }  // namespace
 
 void fused_two_gemms(const torch::Tensor& A, const torch::Tensor& B,
-                     const torch::Tensor& C, torch::Tensor& D) {
+                     const torch::Tensor& C, torch::Tensor& D, int64_t tm,
+                     int64_t tn, int64_t tk, int64_t tp) {
     CHECK_INPUT(A);
     CHECK_INPUT(B);
     CHECK_INPUT(C);
@@ -54,27 +75,22 @@ void fused_two_gemms(const torch::Tensor& A, const torch::Tensor& B,
     const int64_t k = B.size(1);
     const int64_t p = C.size(0);
 
-    // TODO(ying): fix this hard-coded shared memory tile sizes.
-    static constexpr int kTM = 64;
-    static constexpr int kTN = 64;
-    static constexpr int kTK = 64;
-    static constexpr int kTP = 64;
-
+    // TODO(ying): warp layout should be a configurable parameter
     using WarpLayout = tl::RowMajor<2, 1>;
     using InType = __half;
     using AccType = float;
 
-    static constexpr int kShmInput = (kTM * kTK + kTK * kTN + kTN * kTP);
-    static constexpr int kShmOutput = kTM * kTP;
-    static constexpr int kShmSize = kShmInput < kShmOutput
-                                        ? kShmOutput * sizeof(InType)
-                                        : kShmInput * sizeof(InType);
+    // calculate shared memory usage
+    int shm_input = (tm * tk + tk * tn + tn * tp);
+    int shm_output = tm * tp;
+    const int shm_size = shm_input < shm_output ? shm_output * sizeof(InType)
+                                                : shm_input * sizeof(InType);
 
     std::string in_type = jit::get_type_string<InType>();
     std::string acc_type = jit::get_type_string<AccType>();
 
-    std::string kernel_wrapper = generate_kernel_wrapper(
-        in_type, acc_type, m, n, k, p, kTM, kTN, kTK, kTP);
+    std::string kernel_wrapper =
+        generate_kernel_wrapper(in_type, acc_type, m, n, k, p, tm, tn, tk, tp);
 
     std::string kernel_name = "fused_two_gemms_kernel_" + in_type + "_" +
                               acc_type + "_" + std::to_string(m) + "_" +
@@ -103,20 +119,20 @@ void fused_two_gemms(const torch::Tensor& A, const torch::Tensor& B,
     void* args[] = {(void*)&A_ptr, (void*)&B_ptr, (void*)&C_ptr, (void*)&D_ptr,
                     (void*)&m,     (void*)&n,     (void*)&k,     (void*)&p};
 
-    int block_x = ceil_div(m, kTM);
-    int block_y = ceil_div(p, kTP);
+    int block_x = ceil_div(m, tm);
+    int block_y = ceil_div(p, tp);
     int block_z = 1;
     static constexpr int kThreads = tl::get_numel<WarpLayout> * 32;
 
-    if (kShmSize > 48 * 1024) {
-        // Set shared memory size if it exceeds the default limit
+    if (shm_size > GetMaxSharedMemoryPerBlock()) {
+        // Set shared memory size if it exceeds the device limit
         CUDA_DRIVER_CHECK(cuFuncSetAttribute(
-            kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, kShmSize));
+            kernel, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, shm_size));
     }
 
     CUDA_DRIVER_CHECK(cuLaunchKernel(kernel, block_x, block_y, block_z,  // grid
                                      kThreads, 1, 1,  // block
-                                     kShmSize,        // shared memory bytes
+                                     shm_size,        // shared memory bytes
                                      nullptr,         // stream
                                      args,            // kernel parameters
                                      nullptr));       // extra parameters

--- a/tests/python/test_fused_two_gemms.py
+++ b/tests/python/test_fused_two_gemms.py
@@ -50,9 +50,9 @@ def create_tensor(
 
 
 @pytest.mark.parametrize(
-    "kM, kN, kK, kP",
-    [
-        (256, 128, 64, 64),  # TODO(ying): pass more test cases
+    "kM, kN, kK, kP, kTM, kTN, kTK, kTP",
+    [  # TODO(ying): pass more test cases
+        (256, 128, 64, 64, 64, 64, 64, 64),
     ],
 )
 def test_fused_two_gemms(
@@ -60,6 +60,10 @@ def test_fused_two_gemms(
     kN: int,
     kK: int,
     kP: int,
+    kTM: int,
+    kTN: int,
+    kTK: int,
+    kTP: int,
     dtype: torch.dtype,
     device: str,
     tensor_params: dict[str, float],
@@ -89,7 +93,7 @@ def test_fused_two_gemms(
     # It is required that:
     # A and D are laid out in row-major fashion
     # B and C are laid out in column-major fashion
-    fused_two_gemms(input_a, input_b, input_c, output)
+    fused_two_gemms(input_a, input_b, input_c, output, kTM, kTN, kTK, kTP)
     ref = input_a @ input_b.t() @ input_c.t()
 
     print(output)  # noqa: T201


### PR DESCRIPTION
- Exposed shared memory tile size parameters in the `fused_two_gemms` Python function, allowing users to customize the tile size for each dimension.
- Improved CUDA device memory management by using `GetMaxSharedMemoryPerBlock()` to dynamically query device limits.