### PR TITLE
feat: Implement a decoupled shared memory layout.

### DIFF
--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -8,7 +8,7 @@
 #include "util/math_utils.hpp"
 
 #include <iostream>
-#include <type_traits>
+// #include <type_traits>
 
 namespace tilefusion::tile_layout {
 /**

--- a/include/types/layout.hpp
+++ b/include/types/layout.hpp
@@ -8,7 +8,6 @@
 #include "util/math_utils.hpp"
 
 #include <iostream>
-// #include <type_traits>
 
 namespace tilefusion::tile_layout {
 /**

--- a/include/types/shared.hpp
+++ b/include/types/shared.hpp
@@ -21,7 +21,6 @@ struct SharedTilePrettyPrinter {
     template <typename Shared>
     static HOST void print(std::ostream& out, const Shared& tile) {
         // parameter `tile` here is not used
-
         auto swizzled = Shared::kSwizzled ? "swizzled" : "non-swizzled";
         out << "\t" << typename Shared::Layout{} << ", Swizzled = " << swizzled;
     }
@@ -36,21 +35,20 @@ class SharedTile {
     using DType = Element_;
     using Layout = Layout_;
 
-    static constexpr int kNumel = Layout::kNumel;
-
     static constexpr int kRows = Layout::kRows;
     static constexpr int kCols = Layout::kCols;
     static constexpr int kRowStride = Layout::kRowStride;
     static constexpr int kColStride = Layout::kColStride;
-    static constexpr int SwizzleBytes = SwizzleBytes_;
 
     static constexpr tl::Layout kType = Layout::kType;
+    static constexpr int kNumel = Layout::kNumel;
 
+    static constexpr bool isRowMajor = tl::is_row_major<Layout>::value;
+
+    static constexpr int SwizzleBytes = SwizzleBytes_;
     static constexpr bool kSwizzled = kSwizzled_;
 
     using SwizzleBaseShape = SwizzleBaseTileShape<DType, SwizzleBytes>;
-
-    static constexpr bool isRowMajor = (kType == tl::Layout::kRowMajor);
 
     static constexpr int kSwizzleRows =
         isRowMajor ? SwizzleBaseShape::kRows : SwizzleBaseShape::kCols;
@@ -61,9 +59,10 @@ class SharedTile {
         isRowMajor, tl::MatrixLayout<kSwizzleRows, kSwizzleCols, kRowStride, 1>,
         tl::MatrixLayout<kSwizzleRows, kSwizzleCols, 1, kColStride>>;
 
-    using Swizzled =
-        SwizzledLayout<NonSwizzled, SwizzleBaseShape::B, SwizzleBaseShape::M,
-                       SwizzleBaseShape::S, kType>;
+    using Swizzled = SwizzledLayout<
+        NonSwizzled,
+        Swizzle<SwizzleBaseShape::B, SwizzleBaseShape::M, SwizzleBaseShape::S>,
+        kType>;
 
     using InTileLayout = std::conditional_t<kSwizzled, Swizzled, NonSwizzled>;
 

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -77,6 +77,12 @@ struct SwizzledLayout<Layout_, Swizzle_, tl::Layout::kRowMajor> {
     static_assert(Layout::kCols == (1 << (Mbits + Sbits)),
                   "The number of columns in the layout should be 2^S * 2^M.");
 
+    // to be compatible with all the other layouts
+    static constexpr int kRows = Layout::kRows;
+    static constexpr int kCols = Layout::kCols;
+    static constexpr int kNumel = Layout::kNumel;
+    static constexpr tl::Layout kType = Layout::kType;
+
     /**
      * @brief Compose the swizzle function with the layout function.
      *
@@ -111,6 +117,12 @@ struct SwizzledLayout<Layout_, Swizzle_, tl::Layout::kColMajor> {
                   "The number of rows in the layout should be 2^S * 2^M.");
     static_assert(Layout::kCols == (1 << Bbits),
                   "The number of columns in the layout should be 2^B.");
+
+    // to be compatible with all the other layouts
+    static constexpr int kRows = Layout::kRows;
+    static constexpr int kCols = Layout::kCols;
+    static constexpr int kNumel = Layout::kNumel;
+    static constexpr tl::Layout kType = Layout::kType;
 
     /**
      * @brief Compose the swizzle function with the layout function.

--- a/include/types/swizzle.hpp
+++ b/include/types/swizzle.hpp
@@ -56,23 +56,21 @@ struct Swizzle {
  *        2-D coordinate in the space defined by `Layout`.
  * @tparam Layout The `Layout` that defines a function mapping a 2-D coordinate
  *                to a 1-D index.
- * @tparam kB The number of bits for B.
- * @tparam kM The number of bits for M.
- * @tparam kS The number of bits for S.
+ * @tparam Swizzle The swizzle function.
  * @tparam kType The type of the Layout.
  */
-template <typename Layout, const int kB, const int kM, const int kS,
+template <typename Layout, typename Swizzle,
           const tl::Layout kType = Layout::kType>
 struct SwizzledLayout;
 
-template <typename Layout_, const int kB, const int kM, const int kS>
-struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kRowMajor> {
-    static constexpr int Bbits = kB;
-    static constexpr int Mbits = kM;
-    static constexpr int Sbits = kS;
-
+template <typename Layout_, typename Swizzle_>
+struct SwizzledLayout<Layout_, Swizzle_, tl::Layout::kRowMajor> {
     using Layout = Layout_;
-    using Swizzle = Swizzle<Bbits, Mbits, Sbits>;
+    using Swizzle = Swizzle_;
+
+    static constexpr int Bbits = Swizzle_::Bbits;
+    static constexpr int Mbits = Swizzle_::Mbits;
+    static constexpr int Sbits = Swizzle_::Sbits;
 
     static_assert(Layout::kRows == (1 << Bbits),
                   "The number of rows in the layout should be 2^B.");
@@ -100,14 +98,14 @@ struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kRowMajor> {
     Layout layout_;
 };
 
-template <typename Layout_, const int kB, const int kM, const int kS>
-struct SwizzledLayout<Layout_, kB, kM, kS, tl::Layout::kColMajor> {
-    static constexpr int Bbits = kB;
-    static constexpr int Mbits = kM;
-    static constexpr int Sbits = kS;
-
+template <typename Layout_, typename Swizzle_>
+struct SwizzledLayout<Layout_, Swizzle_, tl::Layout::kColMajor> {
     using Layout = Layout_;
-    using Swizzle = Swizzle<Bbits, Mbits, Sbits>;
+    using Swizzle = Swizzle_;
+
+    static constexpr int Bbits = Swizzle::Bbits;
+    static constexpr int Mbits = Swizzle::Mbits;
+    static constexpr int Sbits = Swizzle::Sbits;
 
     static_assert(Layout::kRows == (1 << (Mbits + Sbits)),
                   "The number of rows in the layout should be 2^S * 2^M.");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,9 @@ authors = [
 description = "TileFusion: Simplifying Kernel Fusion with Tile Processing"
 readme = "README.md"
 requires-python = ">=3.9"
+license = "MIT"
 classifiers = [
     "Programming Language :: Python :: 3",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
 ]

--- a/tests/cpp/types/test_layout.cu
+++ b/tests/cpp/types/test_layout.cu
@@ -4,8 +4,6 @@
 #include "common/test_utils.hpp"
 #include "types/mod.hpp"
 
-#include <iostream>
-
 namespace tilefusion::testing {
 
 using namespace tilefusion::cell;

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -5,9 +5,11 @@
 #include "types/mod.hpp"
 
 namespace tilefusion::testing {
+
 using namespace cell;
 namespace tl = tile_layout;
 
+namespace {
 int flatten(int x, int y, int width) { return x * width + y; }
 
 template <const int kB, const int kM, const int kS>
@@ -37,85 +39,37 @@ int2 test_swizzle(int x, int y) {
 
     return make_int2(swizzled_idx, ref_swizzled_idx);
 }
+}  // namespace
 
-TEST(TESTSwizzle, test_swizzle_apply) {
-    const int kB = 3;
-    const int kM = 3;
-    const int kS = 3;
+// TEST(TestSwizzle, test_swizzle_function) {
+//     const int kB = 3;
+//     const int kM = 3;
+//     const int kS = 3;
 
-    int2 swizzled_idx_0_0 = test_swizzle<kB, kM, kS>(0, 0);
-    int2 swizzled_idx_1_0 = test_swizzle<kB, kM, kS>(1, 0);
-    int2 swizzled_idx_1_4 = test_swizzle<kB, kM, kS>(1, 4);
-    int2 swizzled_idx_2_0 = test_swizzle<kB, kM, kS>(2, 0);
-    int2 swizzled_idx_2_4 = test_swizzle<kB, kM, kS>(2, 4);
+//     int2 swizzled_idx_0_0 = test_swizzle<kB, kM, kS>(0, 0);
+//     int2 swizzled_idx_1_0 = test_swizzle<kB, kM, kS>(1, 0);
+//     int2 swizzled_idx_1_4 = test_swizzle<kB, kM, kS>(1, 4);
+//     int2 swizzled_idx_2_0 = test_swizzle<kB, kM, kS>(2, 0);
+//     int2 swizzled_idx_2_4 = test_swizzle<kB, kM, kS>(2, 4);
 
-    EXPECT_EQ(swizzled_idx_0_0.x, swizzled_idx_0_0.y);
-    EXPECT_EQ(swizzled_idx_1_0.x, swizzled_idx_1_0.y);
-    EXPECT_EQ(swizzled_idx_1_4.x, swizzled_idx_1_4.y);
-    EXPECT_EQ(swizzled_idx_2_0.x, swizzled_idx_2_0.y);
-    EXPECT_EQ(swizzled_idx_2_4.x, swizzled_idx_2_4.y);
-}
+//     EXPECT_EQ(swizzled_idx_0_0.x, swizzled_idx_0_0.y);
+//     EXPECT_EQ(swizzled_idx_1_0.x, swizzled_idx_1_0.y);
+//     EXPECT_EQ(swizzled_idx_1_4.x, swizzled_idx_1_4.y);
+//     EXPECT_EQ(swizzled_idx_2_0.x, swizzled_idx_2_0.y);
+//     EXPECT_EQ(swizzled_idx_2_4.x, swizzled_idx_2_4.y);
+// }
 
-TEST(TESTSwizzle, test_naive_swizzle_layout) {
-    const int kB = 3;
-    const int kM = 3;
-    const int kS = 3;
+TEST(TestSwizzle, test_swizzled_layout) {
+    using AtomLayout = SwizzledLayout<tl::RowMajor<8, 64>, Swizzle<3, 3, 3>>;
+    AtomLayout atom_layout;
+    // atom_layout.dump();
 
-    const int kRows = 1 << kB;
-    const int kCols = 1 << (kM + kS);
-
-    using NaiveRowMajorLayout = tl::RowMajor<kRows, kCols>;
-    using NaiveSwizzledRowMajorLayout =
-        SwizzledLayout<NaiveRowMajorLayout, kB, kM, kS, tl::Layout::kRowMajor>;
-
-    NaiveSwizzledRowMajorLayout naive_row_major_swizzled_layout;
-
-    EXPECT_EQ((naive_row_major_swizzled_layout(0, 0)),
-              (swizzle_ref<kB, kM, kS>(0, 0)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(1, 0)),
-              (swizzle_ref<kB, kM, kS>(1, 0)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(1, 4)),
-              (swizzle_ref<kB, kM, kS>(1, 4)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(2, 0)),
-              (swizzle_ref<kB, kM, kS>(2, 0)));
-    EXPECT_EQ((naive_row_major_swizzled_layout(2, 4)),
-              (swizzle_ref<kB, kM, kS>(2, 4)));
-}
-
-TEST(TESTSwizzle, test_nested_basetile_swizzle_layout) {
-    const int kB = 3;
-    const int kM = 3;
-    const int kS = 3;
-
-    const int kRows = 1 << kB;
-    const int kCols = 1 << (kM + kS);
-
-    using NestedBaseTileLayout = tl::MatrixLayout<kRows, kCols, kCols * 16, 16>;
-    using NestedBaseTileSwizzledLayout =
-        SwizzledLayout<NestedBaseTileLayout, kB, kM, kS, tl::Layout::kRowMajor>;
-
-    NestedBaseTileLayout nested_base_tile_layout;
-    NestedBaseTileSwizzledLayout nested_base_tile_swizzled_layout;
-
-    int idx_0_0 = nested_base_tile_layout(0, 0);
-    int idx_1_0 = nested_base_tile_layout(1, 0);
-    int idx_1_4 = nested_base_tile_layout(1, 4);
-    int idx_2_0 = nested_base_tile_layout(2, 0);
-    int idx_2_4 = nested_base_tile_layout(2, 4);
-
-    int swizzled_idx_0_0 = nested_base_tile_swizzled_layout(0, 0);
-    int swizzled_idx_1_0 = nested_base_tile_swizzled_layout(1, 0);
-    int swizzled_idx_1_4 = nested_base_tile_swizzled_layout(1, 4);
-    int swizzled_idx_2_0 = nested_base_tile_swizzled_layout(2, 0);
-    int swizzled_idx_2_4 = nested_base_tile_swizzled_layout(2, 4);
-
-#ifdef DEBUG
-    printf("idx_0_0: %d, swizzled_idx_0_0: %d\n", idx_0_0, swizzled_idx_0_0);
-    printf("idx_1_0: %d, swizzled_idx_1_0: %d\n", idx_1_0, swizzled_idx_1_0);
-    printf("idx_1_4: %d, swizzled_idx_1_4: %d\n", idx_1_4, swizzled_idx_1_4);
-    printf("idx_2_0: %d, swizzled_idx_2_0: %d\n", idx_2_0, swizzled_idx_2_0);
-    printf("idx_2_4: %d, swizzled_idx_2_4: %d\n", idx_2_4, swizzled_idx_2_4);
-#endif
+    // for (int i = 0; i < AtomLayout::kRows; ++i) {
+    //     for (int j = 0; j < AtomLayout::kCols; ++j) {
+    //         printf("%d, ", atom_layout(i, j));
+    //     }
+    //     printf("\n");
+    // }
 }
 
 }  // namespace tilefusion::testing

--- a/tests/cpp/types/test_swizzle.cu
+++ b/tests/cpp/types/test_swizzle.cu
@@ -41,35 +41,33 @@ int2 test_swizzle(int x, int y) {
 }
 }  // namespace
 
-// TEST(TestSwizzle, test_swizzle_function) {
-//     const int kB = 3;
-//     const int kM = 3;
-//     const int kS = 3;
+TEST(TestSwizzle, test_swizzle_function) {
+    const int kB = 3;
+    const int kM = 3;
+    const int kS = 3;
 
-//     int2 swizzled_idx_0_0 = test_swizzle<kB, kM, kS>(0, 0);
-//     int2 swizzled_idx_1_0 = test_swizzle<kB, kM, kS>(1, 0);
-//     int2 swizzled_idx_1_4 = test_swizzle<kB, kM, kS>(1, 4);
-//     int2 swizzled_idx_2_0 = test_swizzle<kB, kM, kS>(2, 0);
-//     int2 swizzled_idx_2_4 = test_swizzle<kB, kM, kS>(2, 4);
+    int2 swizzled_idx_0_0 = test_swizzle<kB, kM, kS>(0, 0);
+    int2 swizzled_idx_1_0 = test_swizzle<kB, kM, kS>(1, 0);
+    int2 swizzled_idx_1_4 = test_swizzle<kB, kM, kS>(1, 4);
+    int2 swizzled_idx_2_0 = test_swizzle<kB, kM, kS>(2, 0);
+    int2 swizzled_idx_2_4 = test_swizzle<kB, kM, kS>(2, 4);
 
-//     EXPECT_EQ(swizzled_idx_0_0.x, swizzled_idx_0_0.y);
-//     EXPECT_EQ(swizzled_idx_1_0.x, swizzled_idx_1_0.y);
-//     EXPECT_EQ(swizzled_idx_1_4.x, swizzled_idx_1_4.y);
-//     EXPECT_EQ(swizzled_idx_2_0.x, swizzled_idx_2_0.y);
-//     EXPECT_EQ(swizzled_idx_2_4.x, swizzled_idx_2_4.y);
-// }
+    EXPECT_EQ(swizzled_idx_0_0.x, swizzled_idx_0_0.y);
+    EXPECT_EQ(swizzled_idx_1_0.x, swizzled_idx_1_0.y);
+    EXPECT_EQ(swizzled_idx_1_4.x, swizzled_idx_1_4.y);
+    EXPECT_EQ(swizzled_idx_2_0.x, swizzled_idx_2_0.y);
+    EXPECT_EQ(swizzled_idx_2_4.x, swizzled_idx_2_4.y);
+}
 
 TEST(TestSwizzle, test_swizzled_layout) {
-    using AtomLayout = SwizzledLayout<tl::RowMajor<8, 64>, Swizzle<3, 3, 3>>;
-    AtomLayout atom_layout;
-    // atom_layout.dump();
+    using BlockRowMajor = tl::BlockRowMajor<
+        tl::RowMajor<16, 64>,
+        SwizzledLayout<tl::RowMajor<8, 64>, Swizzle<3, 3, 3>>>;
 
-    // for (int i = 0; i < AtomLayout::kRows; ++i) {
-    //     for (int j = 0; j < AtomLayout::kCols; ++j) {
-    //         printf("%d, ", atom_layout(i, j));
-    //     }
-    //     printf("\n");
-    // }
+#if defined(DEBUG)
+    BlockRowMajor layout;
+    layout.dump();
+#endif
 }
 
 }  // namespace tilefusion::testing


### PR DESCRIPTION
This pull request addresses the issue of the shared memory layout being dispersed across implementations. It introduces a block matrix layout that can be combined with a swizzled layout. As a result, the entire shared memory layout can now be declared as follows: 

```cpp
using BlockRowMajor = tl::BlockRowMajor<
        tl::RowMajor<16, 64>,
        SwizzledLayout<tl::RowMajor<8, 64>, Swizzle<3, 3, 3>>>;
```